### PR TITLE
Feature/add test utility for generating filename

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,28 @@
 {
-    "typescript.tsdk": "node_modules/typescript/lib/"
+    "[csharp]": {
+        "editor.defaultFormatter": "ms-dotnettools.csharp"
+    },
+    "[scss]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "csharp.format.enable": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.rulers": [100],
+    "json.schemas": [
+        {
+            "fileMatch": ["cypress.json"],
+            "url": "https://on.cypress.io/cypress.schema.json"
+        }
+    ],
+    "prettier.requireConfig": true,
+    "trailing-spaces.trimOnSave": true,
+    "typescript.preferences.quoteStyle": "double",
+    "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/src/utilities/test-utils.test.ts
+++ b/src/utilities/test-utils.test.ts
@@ -3,6 +3,26 @@ import faker from "faker";
 
 describe("TestUtils", () => {
     // -----------------------------------------------------------------------------------------
+    // #region randomFilename
+    // -----------------------------------------------------------------------------------------
+
+    describe("randomFilename", () => {
+        test("it returns a random string with a file extension", () => {
+            // Arrange & Act
+            const result = TestUtils.randomFilename();
+
+            // Assert
+            expect(result).not.toBeEmpty();
+            const name = result.split(".")[0];
+            const extension = result.split(".")[1];
+            expect(name.length).toBeGreaterThanOrEqual(1);
+            expect(extension.length).toBeGreaterThanOrEqual(1);
+        });
+    });
+
+    // #endregion randomFilename
+
+    // -----------------------------------------------------------------------------------------
     // #region randomKey
     // -----------------------------------------------------------------------------------------
 

--- a/src/utilities/test-utils.ts
+++ b/src/utilities/test-utils.ts
@@ -5,6 +5,11 @@ import faker from "faker";
 // -----------------------------------------------------------------------------------------
 
 /**
+ * Wrapper around `faker.system.fileName`
+ */
+const _randomFilename = (): string => faker.system.fileName();
+
+/**
  * Returns a random key from the given object. If the object has no keys, it returns `undefined`.
  *
  * @param {*} obj
@@ -37,6 +42,7 @@ const _randomWord = (): string => faker.random.word().split(" ")[0];
 // -----------------------------------------------------------------------------------------
 
 export const TestUtils = {
+    randomFilename: _randomFilename,
     randomKey: _randomKey,
     randomValue: _randomValue,
     randomWord: _randomWord,


### PR DESCRIPTION
Fixes #7 Add test utility function for generating a random filename 

Turns out the `faker` implementation of `fileName` actually works now - not sure what was up before when I was attempting to use it, but the version we're on now has it.

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
