### PR TITLE
Feature/expose faker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -615,9 +615,9 @@
             "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
         },
         "@types/faker": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.1.2.tgz",
-            "integrity": "sha512-a3FADSHjjinczCwr7tTejoMZzbSS5vi70VCyns4C1idxJrDSRGZCQG0s27YppXLcoWrBOkwBbBsZ9vDRDpQK7A==",
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.3.tgz",
+            "integrity": "sha512-InxkM6sCFQTI6YQl29M/XGlO19ecv/EHH5X5zLEFdge2/qya8oIT0XkJUKTqheVYWJtGi+FBAfP7hbbunDiOmg==",
             "dev": true
         },
         "@types/graceful-fs": {
@@ -1666,9 +1666,9 @@
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "faker": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/faker/-/faker-5.1.0.tgz",
-            "integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw=="
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+            "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
         },
         "fast-deep-equal": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "axios": "0.19.2",
-        "faker": "5.1.0",
+        "faker": "5.5.3",
         "immutable": "4.0.0-rc.12",
         "jest": "25.5.4",
         "jest-extended": "0.11.5",
@@ -19,7 +19,7 @@
     },
     "description": "Commonly used actors for automated testing javascript applications",
     "devDependencies": {
-        "@types/faker": "5.1.2",
+        "@types/faker": "5.5.3",
         "@types/jest": "25.1.5",
         "@types/lodash": "4.14.108",
         "@types/node": "13.11.0",

--- a/src/utilities/test-utils.test.ts
+++ b/src/utilities/test-utils.test.ts
@@ -53,7 +53,7 @@ describe("TestUtils", () => {
                 const obj = {};
                 keys.forEach((key: string) => {
                     // Assign the randomly generated keys to the object
-                    obj[key] = faker.random.uuid();
+                    obj[key] = faker.datatype.uuid();
                 });
 
                 // Act
@@ -136,7 +136,7 @@ describe("TestUtils", () => {
                 const obj = {};
                 keys.forEach((key: string) => {
                     // Assign the randomly generated keys to the object
-                    obj[key] = faker.random.number();
+                    obj[key] = faker.datatype.number();
                 });
 
                 // Act

--- a/src/utilities/test-utils.ts
+++ b/src/utilities/test-utils.ts
@@ -1,104 +1,114 @@
 import faker from "faker";
 
-// -----------------------------------------------------------------------------------------
-// #region Functions
-// -----------------------------------------------------------------------------------------
+const TestUtils = {
+    // -----------------------------------------------------------------------------------------
+    // #region Public Properties
+    // -----------------------------------------------------------------------------------------
 
-/**
- * Randomize case of string
- */
-const randomCase = (str: string): string =>
-    str
-        .split("")
-        .map((char) =>
-            faker.random.boolean() ? char.toUpperCase() : char.toLowerCase()
-        )
-        .join("");
+    faker,
 
-/**
- * Wrapper around `faker.system.fileName`
- */
-const randomFilename = (): string => faker.system.fileName();
+    // #endregion Public Properties
 
-/**
- * Returns a random key from the given object. If the object has no keys, it returns `undefined`.
- *
- * @param {*} obj
- * @returns {string}
- */
-const randomKey = (obj: any): string =>
-    faker.random.arrayElement(Object.keys(obj));
+    // -----------------------------------------------------------------------------------------
+    // #region Public Functions
+    // -----------------------------------------------------------------------------------------
 
-/**
- * Generates random object
- */
-const randomObject = (keyCount?: number) => {
-    const randomObject: Record<string, any> = {};
-    keyCount = keyCount ?? faker.random.number({ min: 1, max: 10 });
+    /**
+     * Randomize case of string
+     */
+    randomCase(value: string): string {
+        return value
+            .split("")
+            .map((char: string) =>
+                faker.datatype.boolean()
+                    ? char.toUpperCase()
+                    : char.toLowerCase()
+            )
+            .join("");
+    },
 
-    for (let i = 0; i < keyCount; i++) {
-        const key = faker.random.uuid();
+    /**
+     * Wrapper around `faker.system.fileName`
+     */
+    randomFilename(): string {
+        return faker.system.fileName();
+    },
 
-        randomObject[key] = randomWord();
-    }
+    /**
+     * Wrapper around `faker.datatype.uuid`
+     */
+    randomGuid(): string {
+        return faker.datatype.uuid();
+    },
 
-    return randomObject;
+    /**
+     * Returns a random key from the given object. If the object has no keys, it returns `undefined`.
+     */
+    randomKey(obj: any): string {
+        return faker.random.arrayElement(Object.keys(obj));
+    },
+
+    /**
+     * Generates random object
+     */
+    randomObject(keyCount?: number): Record<string, string> {
+        const object: Record<string, string> = {};
+        keyCount = keyCount ?? faker.datatype.number({ min: 1, max: 10 });
+
+        for (let i = 0; i < keyCount; i++) {
+            const key = this.randomGuid();
+            object[key] = this.randomWord();
+        }
+
+        return object;
+    },
+    /**
+     * Generates random path
+     */
+    randomPath(): string {
+        return faker.system.directoryPath();
+    },
+
+    /**
+     * Returns a random value from the given object. If the object has no keys, it returns `undefined`.
+     */
+    randomValue<TValue = any>(obj: any): TValue {
+        return obj[this.randomKey(obj)];
+    },
+
+    /**
+     * Wrapper of faker.random.word.
+     *
+     * Unfortunately there is an unresolved bug https://github.com/Marak/faker.js/issues/661
+     * and it will occasionally return multiple which can cause test flake
+     */
+    randomWord(): string {
+        return faker.random
+            .word()
+            .split(" ")[0]
+            .replace(/[^A-Za-z0-9]/gi, "");
+    },
+
+    /**
+     * Returns a string array of at least two random words, leveraging the `TestUtils.randomWord` function
+     */
+    randomWords(): string[] {
+        const words: string[] = [];
+        const count = faker.datatype.number({ min: 2, max: 10 });
+        for (let i = 0; i < count; i++) {
+            words.push(this.randomWord());
+        }
+
+        return words;
+    },
+
+    // #endregion Public Functions
 };
-
-/**
- * Generates random path
- */
-const randomPath = (): string => faker.system.directoryPath();
-
-/**
- * Returns a random value from the given object. If the object has no keys, it returns `undefined`.
- *
- * @template TValue
- * @param {*} obj
- * @returns {TValue}
- */
-const randomValue = <TValue = any>(obj: any): TValue => obj[randomKey(obj)];
-
-/**
- * Wrapper of faker.random.word.
- *
- * Unfortunately there is an unresolved bug https://github.com/Marak/faker.js/issues/661
- * and it will occasionally return multiple which can cause test flake
- */
-const randomWord = (): string =>
-    faker.random
-        .word()
-        .split(" ")[0]
-        .replace(/[^A-Za-z0-9]/gi, "");
-
-/**
- * Returns a string array of at least two random words, leveraging the `TestUtils.randomWord` function
- */
-const randomWords = (): string[] => {
-    const words: string[] = [];
-    const count = faker.random.number({ min: 2, max: 10 });
-    for (let i = 0; i < count; i++) {
-        words.push(randomWord());
-    }
-
-    return words;
-};
-
-// #endregion Functions
 
 // -----------------------------------------------------------------------------------------
 // #region Exports
 // -----------------------------------------------------------------------------------------
 
-export const TestUtils = {
-    randomCase,
-    randomFilename,
-    randomKey,
-    randomObject,
-    randomPath,
-    randomValue,
-    randomWord,
-    randomWords,
-};
+export { TestUtils };
 
 // #endregion Exports


### PR DESCRIPTION
Fixes #21 Expose faker property directly off of TestUtils for ease of consumer usage 

Additionally, adds `randomGuid` wrapper function, restructures `TestUtils` object construction to preserve JSDocs on output, and bumps `faker` to latest version


- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [-] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
